### PR TITLE
Added server.js for starting up Node.js as a webserver for Ripple Emulation testing in Chrome

### DIFF
--- a/ripple-testing/server.js
+++ b/ripple-testing/server.js
@@ -1,0 +1,4 @@
+var connect = require('connect');
+connect.createServer(
+    connect.static(__dirname + '/../www')
+).listen(8080);


### PR DESCRIPTION
Added server.js for starting up Node.js as a webserver for Ripple Emulation testing in Chrome
