### PR TITLE
Don't need the merges directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #Build Folders
 www/phonegap.js
+merges/
 
 # Development Tools
 .project

--- a/merges/.gitignore
+++ b/merges/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Don't need the merges directory as phonegap will generate this. We do need the platforms directory otherwise the build fails. Removed the /merges/.gitignore and added /merges to top level .gitignore
